### PR TITLE
Replace hardcoded shared drive ID with variable

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -81,6 +81,12 @@ The Sheet ID you copied in Step 2.
 1aBcDeFgHiJkLmNoPqRsTuVwXyZ...
 ```
 
+### `SHARED_DRIVE_ID`
+The Google Shared Drive ID where production folders will be created. Find this in the URL when viewing the Shared Drive:
+```
+https://drive.google.com/drive/folders/SHARED_DRIVE_ID_HERE
+```
+
 ### `GOOGLE_SERVICE_ACCOUNT_EMAIL`
 Same value as your Altius Hub — `altius-qc-functions@altius-project-hub.iam.gserviceaccount.com`
 

--- a/netlify/functions/_sheets.js
+++ b/netlify/functions/_sheets.js
@@ -3,6 +3,7 @@
 const { google } = require('googleapis')
 
 const REGISTRY_SHEET_ID = process.env.REGISTRY_SHEET_ID
+const SHARED_DRIVE_ID = process.env.SHARED_DRIVE_ID
 
 function getAuth() {
   const json = process.env.GOOGLE_SERVICE_ACCOUNT_JSON
@@ -85,5 +86,5 @@ function err(msg, code = 400) {
 
 module.exports = {
   getAuth, sheetsClient, driveClient, getRows, appendRows, updateRow,
-  hashPin, makeProductionCode, CORS, ok, err, REGISTRY_SHEET_ID
+  hashPin, makeProductionCode, CORS, ok, err, REGISTRY_SHEET_ID, SHARED_DRIVE_ID
 }

--- a/netlify/functions/createProduction.js
+++ b/netlify/functions/createProduction.js
@@ -2,11 +2,9 @@
 
 const {
   sheetsClient, driveClient, getRows, appendRows,
-  hashPin, makeProductionCode, REGISTRY_SHEET_ID, CORS, ok, err
+  hashPin, makeProductionCode, REGISTRY_SHEET_ID, SHARED_DRIVE_ID, CORS, ok, err
 } = require('./_sheets')
 const { defaultActs, migrateConfig } = require('./_actsScenes')
-
-const SHARED_DRIVE_ID = '0AHO7QedLJaIHUk9PVA'
 
 exports.handler = async (event) => {
   if (event.httpMethod === 'OPTIONS') return { statusCode: 200, headers: CORS, body: '' }

--- a/netlify/functions/updateProduction.js
+++ b/netlify/functions/updateProduction.js
@@ -1,8 +1,6 @@
 'use strict'
 
-const { sheetsClient, driveClient, hashPin, getRows, CORS, ok, err } = require('./_sheets')
-
-const SHARED_DRIVE_ID = '0AHO7QedLJaIHUk9PVA'
+const { sheetsClient, driveClient, hashPin, getRows, SHARED_DRIVE_ID, CORS, ok, err } = require('./_sheets')
 
 function makeInviteCode() {
   const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'


### PR DESCRIPTION
You'll need to add SHARED_DRIVE_ID=0AHO7QedLJaIHUk9PVA to your Netlify environment variables for production deployments.

Resolves #20